### PR TITLE
fix latte filter, replace {!$var} -> {$var|noescape}

### DIFF
--- a/MultipleFileUpload/RegisterJS.latte
+++ b/MultipleFileUpload/RegisterJS.latte
@@ -1,3 +1,3 @@
 <script type="text/javascript">
-new MFUFallbackController(document.getElementById({$id}),{!=json_encode($fallbacks)});
+new MFUFallbackController(document.getElementById({$id}),{=json_encode($fallbacks)|noescape});
 </script>

--- a/MultipleFileUpload/UI/HTML4SingleUpload/html.latte
+++ b/MultipleFileUpload/UI/HTML4SingleUpload/html.latte
@@ -40,15 +40,15 @@ $input =  \Nette\Utils\Html::el("input type=file")->name($mfu->getHtmlName().'[f
 
 <div class="ui-widget ui-widget-content ui-corner-all" style="padding: 5px;">
 	<table cellspacing="5">
-		{? for($i=1;$i<=$maxFiles;$i++): }
+		{for $i=1; $i<=$maxFiles; $i++}
 		<tr>
 			<th>
 				{$i}. soubor
 			</th>
 			<td>
-				{!$input}
+				{$input|noescape}
 			</td>
 		</tr>
-		{? EndFor; }
+		{/for}
 	</table>
 </div>

--- a/MultipleFileUpload/UI/Plupload/initJS.js
+++ b/MultipleFileUpload/UI/Plupload/initJS.js
@@ -5,23 +5,23 @@ var fallbackController = this;
 	// Convert divs to queue widgets when the DOM is ready
 	$(function(){
 		// TODO: auto fallback
-		var uploader = $("#"+{!$id|escapeJs}).pluploadQueue({
+		var uploader = $("#"+{$id|escapeJs|noescape}).pluploadQueue({
 			// General settings
 			runtimes : 'gears,browserplus,silverlight,flash,html5,html4',
 			{* runtimes : 'gears,html5,browserplus,silverlight,html4', *}
 			{* runtimes : 'flash',*}
-			url : {!$uploadLink|escapeJs},
-			max_file_size : {!$sizeLimit},
+			url : {$uploadLink|escapeJs|noescape},
+			max_file_size : {$sizeLimit|noescape},
 			chunk_size : '5mb',
 			
 			// Intentionally do not use headers, because not all interfaces allows you to send them.
 			// insted using parameters in URL or POST
 			
 			// Flash settings
-			flash_swf_url : {!$interface->baseUrl|escapeJs}+'/swf/plupload.flash.swf',
+			flash_swf_url : {$interface->baseUrl|escapeJs|noescape}+'/swf/plupload.flash.swf',
 
 			// Silverlight settings
-			silverlight_xap_url : {!$interface->baseUrl|escapeJs}+'/xap/plupload.silverlight.xap'
+			silverlight_xap_url : {$interface->baseUrl|escapeJs|noescape}+'/xap/plupload.silverlight.xap'
 		});
 		uploader = $(uploader).pluploadQueue();
 		console.log(uploader);

--- a/MultipleFileUpload/UI/Swfupload/html.latte
+++ b/MultipleFileUpload/UI/Swfupload/html.latte
@@ -33,11 +33,11 @@
 * @license    New BSD License
 * @link       http://nettephp.com/cs/extras/multiplefileupload
 *}
-<div class="swfuflashupload" id="{!$swfuId}">
-	<div class="fieldset swfuflash" id="{!$swfuId}progress">
+<div class="swfuflashupload" id="{$swfuId|noescape}">
+	<div class="fieldset swfuflash" id="{$swfuId|noescape}progress">
 		<span class="legend">Fronta souborů: </span>
-		<span id="{!$swfuId}placeHolder"></span>
+		<span id="{$swfuId|noescape}placeHolder"></span>
 	</div>
 	<div class="divStatus">0 Files Uploaded</div>
-	<input id="{$swfuId}btnCancel" type="button" value="Přerušit nahrávání" onclick="$('#{!$swfuId}').swfupload('cancelQueue');" disabled="disabled" />
+	<input id="{$swfuId}btnCancel" type="button" value="Přerušit nahrávání" onclick="$('#{$swfuId|noescape}').swfupload('cancelQueue');" disabled="disabled" />
 </div>

--- a/MultipleFileUpload/UI/Swfupload/initJS.js
+++ b/MultipleFileUpload/UI/Swfupload/initJS.js
@@ -1,30 +1,30 @@
 (function($){
 
-    $("#{!$swfuId}").swfupload({
-            flash_url : {!=\Nette\Environment::expand("{$interface->baseUrl}/swf/swfupload.swf")|escapeJS},
-            flash9_url : {!=\Nette\Environment::expand("{$interface->baseUrl}/swf/swfupload_fp9.swf")|escapeJS},
-            upload_url: {!$backLink|escapeJS},
+    $("#{$swfuId|noescape}").swfupload({
+            flash_url : {=\Nette\Environment::expand("{$interface->baseUrl}/swf/swfupload.swf")|escapeJS|noescape},
+            flash9_url : {=\Nette\Environment::expand("{$interface->baseUrl}/swf/swfupload_fp9.swf")|escapeJS|noescape},
+            upload_url: {$backLink|escapeJS|noescape},
             post_params: {
-                token : {!$token|escapeJS},
+                token : {$token|escapeJS|noescape},
                 sender: "MFU-Swfupload"
             },
 
-            file_size_limit : {!$sizeLimit|escapeJS},
+            file_size_limit : {$sizeLimit|escapeJS|noescape},
             file_types : "*.*",
             file_types_description : "All Files",
-            file_upload_limit : {!$maxFiles|escapeJS},
+            file_upload_limit : {$maxFiles|escapeJS|noescape},
 
             custom_settings : {
-                    progressTarget : "{!$swfuId}progress",
-                    cancelButtonId : "{!$swfuId}btnCancel"
+                    progressTarget : "{$swfuId|noescape}progress",
+                    cancelButtonId : "{$swfuId|noescape}btnCancel"
             },
             debug: false,
 
             // Button settings
-            button_image_url: {!=\Nette\Environment::expand("{$interface->baseUrl}/imgs/XPButtonUploadText_89x88.png")|escapeJS},
+            button_image_url: {=\Nette\Environment::expand("{$interface->baseUrl}/imgs/XPButtonUploadText_89x88.png")|escapeJS|noescape},
             button_width: "89",
             button_height: "22",
-            button_placeholder_id : "{!$swfuId}placeHolder",
+            button_placeholder_id : "{$swfuId|noescape}placeHolder",
     });
 
     return true;

--- a/MultipleFileUpload/UI/Uploadify/initJS.js
+++ b/MultipleFileUpload/UI/Uploadify/initJS.js
@@ -1,6 +1,6 @@
 (function($){
 
-	var uploadifyId = {!$uploadifyId|escapeJS};
+	var uploadifyId = {$uploadifyId|escapeJS|noescape};
 	var queue = $('#' + uploadifyId + '-queue');
 	var clearQueueButton = $('#' + uploadifyId + 'ClearQueue');
 	var uploadify = $('#' + uploadifyId);
@@ -9,9 +9,9 @@
 	uploadify.uploadify({
 		auto: false,
 		buttonImage: {!=\Nette\Environment::expand("{$baseModulePath}/images/uploadify/uploadifyButton.png")|escapeJS},
-		fileSizeLimit: {!$sizeLimit|escapeJS},
+		fileSizeLimit: {$sizeLimit|escapeJS|noescape},
 		formData: {
-			token: {!$token|escapeJS},
+			token: {$token|escapeJS|noescape},
 			sender: 'MFU-Uploadify'
 		},
 		height: 22,
@@ -19,10 +19,10 @@
 		multi: true,
 		overrideEvents: ['onQueueComplete'],
 		queueID: uploadifyId + '-queue',
-		queueSizeLimit: {!$maxFiles|escapeJS},
+		queueSizeLimit: {$maxFiles|escapeJS|noescape},
 		removeCompleted: true,
 		swf: {!=\Nette\Environment::expand("{$baseModulePath}/swf/uploadify/uploadify.swf")|escapeJS},
-		uploader: {!$backLink|escapeJS},
+		uploader: {$backLink|escapeJS|noescape},
 		width: 70,
         
 		/**


### PR DESCRIPTION
v nové verzi Nette to hlásí chybu: 
The noescape shortcut {!...} is deprecated, use {...|noescape} modifier on line 
